### PR TITLE
[Feature] Support Read Environment Variable from Config

### DIFF
--- a/pjtools/configurator/configurator.py
+++ b/pjtools/configurator/configurator.py
@@ -54,6 +54,10 @@ class JSONConfigurator(BaseConfigurator):
         with open(filepath, 'r') as f:
             config_dict = json.load(f)
 
+        config_dict = {
+            k: BaseConfigurator._resolve_env_vars(v)
+            for k, v in config_dict.items()
+        }
         return config_dict
 
 
@@ -160,6 +164,10 @@ class PyConfigurator(BaseConfigurator):
                 attribute = getattr(config_module, attribute_name)
                 config_dict[attribute_name] = attribute
 
+        config_dict = {
+            k: PyConfigurator._resolve_env_vars(v)
+            for k, v in config_dict.items()
+        }
         return config_dict, base_files
 
 
@@ -207,6 +215,10 @@ class YAMLConfigurator(BaseConfigurator):
         with open(filepath, 'r') as f:
             config_dict = yaml.safe_load(f)
 
+        config_dict = {
+            k: BaseConfigurator._resolve_env_vars(v)
+            for k, v in config_dict.items()
+        }
         return config_dict
 
 

--- a/tests/configurator/test_json_config.py
+++ b/tests/configurator/test_json_config.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import unittest
 
@@ -46,3 +47,9 @@ class TestJSONConfigurator(unittest.TestCase):
 
             self.assertEqual(loaded_config.to_dict(),
                              self.default_config.to_dict())
+
+    def test_env_var_loading(self):
+        os.environ['PJTOOLS_DUMMY_TEST_DATABASE_URL'] = '127.0.0.1'
+        config = JSONConfigurator.fromfile('tests/data/dummy_config.json')
+        self.assertEqual(config.database.url, '127.0.0.1')
+        del os.environ['PJTOOLS_DUMMY_TEST_DATABASE_URL']

--- a/tests/configurator/test_py_config.py
+++ b/tests/configurator/test_py_config.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import unittest
 
@@ -58,3 +59,11 @@ class TestPyConfigurator(unittest.TestCase):
 
             self.assertEqual(loaded_config.to_dict(),
                              self.default_config.to_dict())
+
+    def test_env_var_loading(self):
+        os.environ[
+            'PJTOOLS_DUMMY_TEST_DATABASE_URL'] = 'mysql://user:pass@localhost/dbname'
+        config = PyConfigurator.fromfile('tests/data/dummy_config.py')
+        self.assertEqual(config.database_url,
+                         'mysql://user:pass@localhost/dbname')
+        del os.environ['PJTOOLS_DUMMY_TEST_DATABASE_URL']

--- a/tests/configurator/test_yaml_config.py
+++ b/tests/configurator/test_yaml_config.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import unittest
 
@@ -44,3 +45,9 @@ class TestYAMLConfigurator(unittest.TestCase):
             self.config.dumpfile(tmp_path, format='yaml')
             loaded_config = YAMLConfigurator.fromfile(tmp_path)
             self.assertEqual(loaded_config.to_dict(), self.config.to_dict())
+
+    def test_env_var_loading(self):
+        os.environ['PJTOOLS_DUMMY_TEST_DATABASE_URL'] = '127.0.0.1'
+        config = YAMLConfigurator.fromfile('tests/data/dummy_config.json')
+        self.assertEqual(config.database.url, '127.0.0.1')
+        del os.environ['PJTOOLS_DUMMY_TEST_DATABASE_URL']

--- a/tests/data/dummy_config.json
+++ b/tests/data/dummy_config.json
@@ -3,6 +3,7 @@
         "host": "localhost",
         "port": 5432,
         "user": "root",
+        "url": "env:PJTOOLS_DUMMY_TEST_DATABASE_URL",
         "password": "password"
     },
     "api": {

--- a/tests/data/dummy_config.py
+++ b/tests/data/dummy_config.py
@@ -18,3 +18,5 @@ data_transforms = {
 }
 
 additional_info = 'This is a dummy config'
+
+database_url = 'env:PJTOOLS_DUMMY_TEST_DATABASE_URL'

--- a/tests/data/dummy_config.yaml
+++ b/tests/data/dummy_config.yaml
@@ -25,3 +25,4 @@ data_transforms:
     flip: true
 
 additional_info: "This is a sample config"
+url: "env:PJTOOLS_DUMMY_TEST_DATABASE_URL"


### PR DESCRIPTION
Now configurator support to use "env:" flag in configs to read parameters from environment variables.

For example:
```
database_pwd = 'env:PASSWORD'
```
This allows the configurator tries to use `os.environ.get('PASSWORD')` to get `PASSWORD`.